### PR TITLE
Change dev script click event target from document to minimize button

### DIFF
--- a/packages/slate-tools/src/tasks/includes/dev-script.js
+++ b/packages/slate-tools/src/tasks/includes/dev-script.js
@@ -21,7 +21,11 @@
   if (!isSessionStorageSupported()) { return; }
 
   window.addEventListener('DOMContentLoaded', function() {
-    document.addEventListener('click', onButtonClick);
+    var previewBarMinimizeElement = document.getElementsByClassName('shopify-preview-bar__minimize');
+
+    if (previewBarMinimizeElement.length > 0) {
+      previewBarMinimizeElement[0].addEventListener('click', onButtonClick);
+    }
 
     if (window.sessionStorage.getItem('preview-bar-hidden')) {
       hidePreviewBar();
@@ -30,8 +34,6 @@
 
   function onButtonClick(event) {
     var element = event.target;
-
-    if (element.className.indexOf('shopify-preview-bar__minimize') === -1) { return; }
 
     window.sessionStorage.setItem('preview-bar-hidden', 'true');
     hidePreviewBar();


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Change the dev-scripts click event to bind on just the minimize button on the preview bar instead of on the entire document.


### Checklist
For contributors:
- [X] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

